### PR TITLE
remove an errant 'use HTML::Lint'

### DIFF
--- a/t/autolint.t
+++ b/t/autolint.t
@@ -5,7 +5,6 @@ use warnings;
 use Test::Builder::Tester;
 use Test::More;
 use URI::file;
-use HTML::Lint;
 
 BEGIN {
     eval 'use HTML::Lint';


### PR DESCRIPTION
$ perl -T -Ilib t/autolint.t 
Can't locate HTML/Lint.pm in @INC (@INC contains: lib /Users/r.clamp/perl5/perlbrew/perls/perl-5.12.3/lib/site_perl/5.12.3/darwin-2level /Users/r.clamp/perl5/perlbrew/perls/perl-5.12.3/lib/site_perl/5.12.3 /Users/r.clamp/perl5/perlbrew/perls/perl-5.12.3/lib/5.12.3/darwin-2level /Users/r.clamp/perl5/perlbrew/perls/perl-5.12.3/lib/5.12.3) at t/autolint.t line 8.
