### PR TITLE
Added PID to pseudo-random port in TestServer.

### DIFF
--- a/t/TestServer.pm
+++ b/t/TestServer.pm
@@ -21,8 +21,8 @@ sub new {
 
     die 'An instance of TestServer has already been started.' if $pid;
 
-    # XXX This should really be a random port.
-    return $class->SUPER::new(13432, @_);
+    # give port some randomness to improve parallel testing
+    return $class->SUPER::new(13432 + $$, @_);
 }
 
 sub run {


### PR DESCRIPTION
Added PID to pseudo-random port in TestServer. This fixes repeatable failures when running parallel tests.

If you have a better way to fix this, so be it -- but it's definitely been the source of automated installation troubles for me.
