### PR TITLE
particle's T:WWW:Mech win32 slashie fix

### DIFF
--- a/t/follow_link_ok.t
+++ b/t/follow_link_ok.t
@@ -24,13 +24,11 @@ FOLLOW_BAD_LINK: {
     my $mech = Test::WWW::Mechanize->new( autocheck => 0 );
     isa_ok( $mech, 'Test::WWW::Mechanize' );
 
-    my $uri = URI::file->new_abs( 't/badlinks.html' )->as_string;
-
-    my $path = $uri;
-    $path =~ s{file://}{};
+    my $uri = URI::file->new_abs( 't/badlinks.html' );
+    my $path = $uri->file;
     $path =~ s{\Qbadlinks.html}{bad1.html};
 
-    $mech->get_ok( $uri );
+    $mech->get_ok( $uri->as_string );
     test_out('not ok 1 - Go after bad link');
     test_fail(+3);
     test_diag( 404 ); # XXX Who is printing this 404, and should it be?

--- a/t/get_ok.t
+++ b/t/get_ok.t
@@ -29,16 +29,16 @@ GOOD_GET: {
 }
 
 BAD_GET: {
-    my $badurl = URI::file->new_abs('t/no-such-file')->as_string;
-    (my $abs_path = $badurl) =~ s{^file://}{};
-    $mech->get($badurl);
+    my $badurl = URI::file->new_abs('t/no-such-file');
+    my $abs_path = $badurl->file;
+    $mech->get( $badurl->as_string );
     ok(!$mech->success, qq{sanity check: we can't load $badurl});
 
     test_out( 'not ok 1 - Try to get bad URL' );
     test_fail( +3 );
     test_diag( '404' );
     test_diag( qq{File `$abs_path' does not exist} );
-    my $ok = $mech->get_ok( $badurl, 'Try to get bad URL' );
+    my $ok = $mech->get_ok( $badurl->as_string, 'Try to get bad URL' );
     test_test( 'Fails to get nonexistent URI and reports failure' );
 
     is( ref($ok), '', 'get_ok() should only return a scalar' );

--- a/t/head_ok.t
+++ b/t/head_ok.t
@@ -30,16 +30,16 @@ GOOD_HEAD: { # Stop giggling, you!
 }
 
 BAD_HEAD: {
-    my $badurl = URI::file->new_abs('t/no-such-file')->as_string;
-    ( my $abs_path = $badurl ) =~ s{^file://}{};
-    $mech->head($badurl);
+    my $badurl = URI::file->new_abs('t/no-such-file');
+    my $abs_path = $badurl->file;
+    $mech->head( $badurl->as_string );
     ok(!$mech->success, qq{sanity check: we can't load $badurl} );
 
     test_out( 'not ok 1 - Try to HEAD bad URL' );
     test_fail( +3 );
     test_diag( '404' );
     test_diag( qq{File `$abs_path' does not exist} );
-    my $ok = $mech->head_ok( $badurl, 'Try to HEAD bad URL' );
+    my $ok = $mech->head_ok( $badurl->as_string, 'Try to HEAD bad URL' );
     test_test( 'Fails to HEAD nonexistent URI and reports failure' );
 
     is( ref($ok), '', 'head_ok() should only return a scalar' );


### PR DESCRIPTION
Previously tests hand-converted URIs to filenames.
This patch modifies these conversions to use the URI module's 'file'
object method.
This is the smallest working patch in keeping with the current style of
using the 'as_string' URI method for stringification.
Alternatively, URI provides stringification via double-quote override;
here I have respected the stylistic decisions of the author.
