### PR TITLE
Add 2.20 dep to .t as well

### DIFF
--- a/t/html_lint_ok.t
+++ b/t/html_lint_ok.t
@@ -10,7 +10,7 @@ use URI::file;
 
 BEGIN {
     # Load HTML::Lint here for the imports
-    if ( not eval 'use HTML::Lint;' ) {
+    if ( not eval 'use HTML::Lint 2.20; 1;' ) {
         plan skip_all => 'HTML::Lint is not installed, cannot test autolint' if $@;
     }
     plan tests => 3;


### PR DESCRIPTION
`Makefile.PL` has a test for version 2.20 of `HTML::Lint`, but the test `t/html_lint_ok.t` does not, so the test can fail if the installed `HTML::Lint` is too old. This pull request adds the same 2.20 to the eval in the test, and skips if it isn't installed.
