### PR TITLE
inspect_visually - Inspect the html content in a browser whilst developping.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+**~
 Makefile
 Makefile.old
 blib/

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,6 +10,7 @@ my $parms = {
     PL_FILES            => {},
     PREREQ_PM => {
         'Carp::Assert::More'        => 0,
+        'File::Temp'                => 0.22,
         'HTML::TreeBuilder'         => 0,
         'HTTP::Server::Simple'      => '0.42',
         'HTTP::Server::Simple::CGI' => 0,
@@ -17,6 +18,7 @@ my $parms = {
         'Test::Builder::Tester'     => '1.09',
         'Test::LongString'          => '0.15',
         'Test::More'                => '0.96', # subtest() and done_testing()
+        'Scalar::Util'              => 1.23,
         'URI::file'                 => 0,
         'WWW::Mechanize'            => '1.68',
     },

--- a/Mechanize.pm
+++ b/Mechanize.pm
@@ -1663,8 +1663,12 @@ sub scraped_id_is {
 Launches a browser to visually inspect the current content() of this L<Test::WWW::Mechanize> client.
 See browser_command().
 
+NOTE: You need to have un UNTAINTED version of $ENV{PATH} for this to work in a tainted environment.
+
 
 Usage:
+
+  $ENV{PATH} = '/usr/bin/'; ## If you run in tainted mode
 
   $mech->inspect_visually();
   ## With a specific browser:

--- a/t/inspect_visually.t
+++ b/t/inspect_visually.t
@@ -1,0 +1,56 @@
+#!perl -T
+
+use strict;
+use warnings;
+use Test::More tests => 3;
+use Test::Builder::Tester;
+use URI::file ();
+use File::Temp;
+
+use Test::WWW::Mechanize ();
+
+## Set PATH so it'not tainted.
+$ENV{PATH} = '/usr/bin/';
+
+
+my $fake_output = File::Temp->new( SUFFIX => '.out' );
+my $fake_output_fname = $fake_output->filename();
+my $fake_browser = q|#!|.$^X.q| -T
+## Good old Perl.
+use strict;
+use warnings;
+my $fname = shift;
+$fname =~ s/^file:\/\///;
+open FILE , '<' , $fname;
+binmode FILE;
+$/ = undef;
+my $content = <FILE>;
+close FILE;
+open OUT , '>' ,'|.$fake_output_fname.q|';
+binmode OUT;
+print OUT $content;
+close OUT;
+exit(0);
+|;
+
+my $fake_browser_ft = File::Temp->new(SUFFIX => '.pl');
+my $fake_browser_filename = $fake_browser_ft->filename();
+chmod 0700, $fake_browser_filename;
+print $fake_browser_ft  $fake_browser;
+close $fake_browser_ft;
+
+
+my $mech = Test::WWW::Mechanize->new( autocheck => 0 , browser_command => $fake_browser_filename.' !!URL!!');
+isa_ok($mech,'Test::WWW::Mechanize');
+
+my $page = URI::file->new_abs( 't/goodlinks.html' )->as_string;
+
+$mech->get_ok($page);
+
+$mech->inspect_visually();
+
+## Check our fake browser has output the right thing
+my $content = do{ local $/ = undef; open FILE , '<' , $fake_output; my $content = <FILE>; close FILE; $content; };
+is($content , $mech->content() , "Our fake browser did read and output the right file");
+
+done_testing();


### PR DESCRIPTION
This feature allows you to have a visual look at the current html content of the Test::Mechanize object when you're writing your Test::WWW::Mechanized based test:

For instance:

 $mech->get_ok('/whatever' );
 $mech->content_like(qr{something}); ## Fails but why ??
 ## Have a look at it on your dev box!
 $mech->inspect_visually();
