### PR TITLE
Proposal to add header_exists and header_matches.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -21,6 +21,7 @@ t/goodlinks.html
 t/has_tag.t
 t/head_ok-parms.t
 t/head_ok.t
+t/headers.t
 t/html/form.html
 t/html_lint_ok.t
 t/html/scratch.html

--- a/Mechanize.pm
+++ b/Mechanize.pm
@@ -1640,6 +1640,51 @@ sub scraped_id_is {
 }
 
 
+=head2 $mech->header_exists( $field, $desc )
+
+Assures that a given response header exists. The actual value of the response header is not checked, only that the header exists.
+
+=cut
+
+sub header_exists {
+    my $self = shift;
+    my $field = shift;
+    my $desc = shift || qq{Response has $field header};
+
+    my $ok = defined($self->response->header($field));
+
+    $TB->ok( $ok, $desc );
+    if ( !$ok ) {
+        $TB->diag( HTTP::Headers::as_string($self->response) ) if $self->response;
+    }
+
+    return $ok;
+}
+
+=head2 $mech->header_matches( $field, $value, $desc )
+
+Assures that a given response header exists and has the given value.  Value may be a string or a regular expression.
+
+=cut
+
+sub header_matches {
+    my $self = shift;
+    my $field = shift;
+    my $value = shift;
+    my $desc = shift || qq{Response has $field header with value '$value'};
+
+    my $ok = (ref($value) eq 'Regexp')
+       ? scalar $self->response->header($field) =~ $value
+       : scalar $self->response->header($field) eq $value;
+
+    $TB->ok( $ok, $desc );
+    if ( !$ok ) {
+        $TB->diag( $self->response->header($field) ) if $self->response;
+    }
+    return $ok;
+}
+
+
 =head1 TODO
 
 Add HTML::Tidy capabilities.

--- a/t/headers.t
+++ b/t/headers.t
@@ -1,0 +1,92 @@
+#!perl -T
+
+use strict;
+use warnings;
+use Test::More tests => 19;
+use Test::Builder::Tester;
+
+use lib 't';
+use TestServer;
+
+my $server      = TestServer->new;
+my $pid         = $server->background;
+my $server_root = $server->root;
+
+use Test::WWW::Mechanize ();
+
+my $mech = Test::WWW::Mechanize->new( autocheck => 0 );
+isa_ok($mech,'Test::WWW::Mechanize');
+$mech->get_ok( "$server_root/form.html" );
+
+GOOD_EXISTS: {
+    test_out( 'ok 1 - Has Content-Type' );
+    my $ok = $mech->header_exists('Content-Type', 'Has Content-Type');
+    test_test( 'Gets existing header and reports success' );
+    is( ref($ok), '', 'get_ok() should only return a scalar' );
+    ok( $ok, 'And the result should be true' );
+
+    # default desc
+    test_out( 'ok 1 - Response has Content-Type header' );
+    $mech->header_exists('Content-Type');
+    test_test( 'Gets existing header and reports success - default desc' );
+}
+
+BAD_EXISTS: {
+    test_out( 'not ok 1 - Try to get a bad header' );
+    test_fail( +1 );
+    my $ok = $mech->header_exists('Server', 'Try to get a bad header');
+    test_diag( 'Content-Length: ' );
+    test_diag( 'Content-Type: ' );
+    test_diag( 'client-date: ' );
+    test_diag( 'client-peer: ' );
+    test_diag( 'client-response-num: ' );
+    test_diag( 'title: ' );
+    test_test( 'Fails to get nonexistent header and reports failure' );
+
+    is( ref($ok), '', 'get_ok() should only return a scalar' );
+    ok( !$ok, 'And the result should be false' );
+}
+
+GOOD_MATCHES: {
+    test_out( 'ok 1 - Content-Type is "text/html"' );
+    my $ok = $mech->header_matches('Content-Type', 'text/html', 'Content-Type is "text/html"');
+    test_test( 'Matches existing header and reports success' );
+    is( ref($ok), '', 'get_ok() should only return a scalar' );
+    ok( $ok, 'And the result should be true' );
+
+    # regex
+    test_out( 'ok 1 - Content-Type matches /^text\\/html$/' );
+    $mech->header_matches('Content-Type', qr/^text\/html$/, 'Content-Type matches /^text\\/html$/');
+    test_test( 'Matches existing header and reports success - regex' );
+
+    # default desc
+    test_out( 'ok 1 - Response has Content-Type header with value \'text/html\'' );
+    $mech->header_matches('Content-Type', 'text/html');
+    test_test( 'Matches existing header and reports success - default desc' );
+}
+
+BAD_MATCHES: {
+    test_out( 'not ok 1 - Try to match a bad header' );
+    test_fail( +1 );
+    my $ok = $mech->header_matches('Server', 'GitHub.com', 'Try to match a bad header');
+    test_test( 'Fails to match nonexistent header and reports failure' );
+
+    is( ref($ok), '', 'get_ok() should only return a scalar' );
+    ok( !$ok, 'And the result should be false' );
+
+    test_out( 'not ok 1 - Content-Type is "text/plain"' );
+    test_fail( +1 );
+    $mech->header_matches('Content-Type', 'text/plain', 'Content-Type is "text/plain"');
+    test_diag( 'text/html' );
+    test_test( 'Fails to match header and reports failure' );
+
+    test_out( 'not ok 1 - Content-Type matches /^text\\/plain$/' );
+    test_fail( +1 );
+    $mech->header_matches('Content-Type', qr/^text\/plain$/, 'Content-Type matches /^text\\/plain$/');
+    test_diag( 'text/html' );
+    test_test( 'Fails to match header and reports failure - regex' );
+}
+
+$server->stop;
+
+done_testing();

--- a/tags
+++ b/tags
@@ -7,7 +7,9 @@
 ACCESSOR	t/autolint.t	/^    ACCESSOR: {$/;"	l
 ACCESSOR_MUTATOR	t/autolint.t	/^ACCESSOR_MUTATOR: {$/;"	l
 BAD	t/lacks_uncapped_inputs.t	/^BAD: {$/;"	l
+BAD_EXISTS	t/headers.t	/^BAD_EXISTS: {$/;"	l
 BAD_GET	t/get_ok.t	/^BAD_GET: {$/;"	l
+BAD_MATCHES	t/headers.t	/^BAD_MATCHES: {$/;"	l
 CONSTRUCTOR_PARMS	t/new.t	/^CONSTRUCTOR_PARMS: {$/;"	l
 CUSTOM_FILL	t/stuff_inputs.t	/^    CUSTOM_FILL: {$/;"	l
 CUSTOM_LINTER	t/autolint.t	/^CUSTOM_LINTER: {$/;"	l
@@ -15,12 +17,14 @@ EMPTY_FIELDS	t/stuff_inputs.t	/^    EMPTY_FIELDS: {$/;"	l
 FOLLOW_BAD_LINK	t/follow_link_ok.t	/^FOLLOW_BAD_LINK: {$/;"	l
 FOLLOW_GOOD_LINK	t/follow_link_ok.t	/^FOLLOW_GOOD_LINK: {$/;"	l
 GOOD	t/lacks_uncapped_inputs.t	/^GOOD: {$/;"	l
+GOOD_EXISTS	t/headers.t	/^GOOD_EXISTS: {$/;"	l
 GOOD_GET	hanger	/^GOOD_GET: {$/;"	l
 GOOD_GET	t/get_ok.t	/^GOOD_GET: {$/;"	l
 GOOD_GET	t/html_lint_ok.t	/^GOOD_GET: {$/;"	l
 GOOD_GET_BAD_HTML	t/autolint.t	/^GOOD_GET_BAD_HTML: {$/;"	l
 GOOD_GET_GOOD_HTML	t/autolint.t	/^GOOD_GET_GOOD_HTML: {$/;"	l
 GOOD_HEAD	t/head_ok.t	/^GOOD_HEAD: { # Stop giggling, you!$/;"	l
+GOOD_MATCHES	t/headers.t	/^GOOD_MATCHES: {$/;"	l
 GOOD_PUT	t/put_ok.t	/^GOOD_PUT: {$/;"	l
 HangServer	hanger	/^package HangServer;$/;"	p
 IGNORE	t/stuff_inputs.t	/^    IGNORE: {$/;"	l


### PR DESCRIPTION
Andy,

Someone sent me a link to https://github.com/commando/dogpatch, and it seemed to me that adding header_exists and header_matches to Test::WWW::Mechanize (and therefore child classes like Test::WWW:Mechanize::JSON) would be a good improvement.  This is a first pass, may need some adjustments, and definitely could use some better docs as well as any tests.  It just seemed easier to describe the feature request by throwing up something.

Here is an example that corresponds to the first one in dogpatch:
```
use Test::More tests => 5;
use Test::WWW::Mechanize::JSON;

my $mech = Test::WWW::Mechanize::JSON->new;

$mech->get("https://api.github.com");
ok( $mech->success );
$mech->header_exists("X-GitHub-Request-Id");
$mech->header_exists("ETag");
$mech->header_matches("Server", "GitHub.com");
$mech->json_ok or BAIL_OUT Dumper $mech->response;
```

Regards,
-Eric