### PR TITLE
Added additional documentation about post_ok limitations.

### DIFF
--- a/Mechanize.pm
+++ b/Mechanize.pm
@@ -224,6 +224,12 @@ the second argument needs to be a hash reference, not a hash. Like
 well-behaved C<*_ok()> functions, it returns true if the test passed,
 or false if not.
 
+B<NOTE> Due to compatibility reasons it is not possible to pass
+additional LWP_options beyond form data via this method (such as
+Content or Content-Type).  It is recommend that you use WWW::Mechanize's
+post() directly for instances where more granular control of the post
+is needed.
+
 A default description of "POST to $url" is used if none if provided.
 
 =cut


### PR DESCRIPTION
I know this pull request and issue are practically ancient, but I just spent hours tracing and ultimately tracking down this exact conclusion (embarrassing to say the least).  I'd like to propose this compromise pull request as a way to resolve #18 .

I can certainly understand and respect the need to preserve the interface.  For the time being, would we be open to a documentation change on Test::WWW::Mechanize?  This change simply adds additional documentation to post_ok and recommends using WWW::Mechanize's post directly if you need more granular control over the actual post request generated.

In Mechanize.pm
  Updated POD for post_ok to mention that only form data can really be
  sent and that if a consumer needs more control over aspects of the
  request such as Headers they should use WWW::Mechanize's post method
  directly.

I'm open to further discussion or refinement, I'd just like to spare the next guy a bit of confusion.  Thanks for considering it!
