### PR TITLE
Fix click_ok.t to work with http proxy env vars set

### DIFF
--- a/t/click_ok.t
+++ b/t/click_ok.t
@@ -15,7 +15,10 @@ my $pid         = $server->background;
 my $server_root = $server->root;
 
 SUBMIT_GOOD_FORM: {
-    my $mech = Test::WWW::Mechanize->new();
+    my $mech = do {
+                   local @ENV{qw[ http_proxy HTTP_PROXY ]};
+                   Test::WWW::Mechanize->new();
+                  };
     isa_ok( $mech,'Test::WWW::Mechanize' );
 
     $mech->get_ok( "$server_root/form.html" );


### PR DESCRIPTION
I get consistent test failures without this patch:
```
Running make test
PERL_DL_NONLAZY=1 "/usr/local/bin/perl5.26.0" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/00-load.t ................ 1/1 # Testing Test::WWW::Mechanize 1.48, with WWW::Mechanize 1.86, LWP 6.27, Test::More 1.302106, Perl 5.026000, /usr/local/bin/perl5.26.0
t/00-load.t ................ ok   
t/autolint.t ............... skipped: HTML::Lint 2.20 is not installed, cannot test autolint
t/click_ok.t ............... # Test server http://127.0.0.1:37312 as PID 71946
t/click_ok.t ............... 1/3 
#   Failed test 'GET http://127.0.0.1:37312/form.html'
#   at t/click_ok.t line 21.
# 403
# Forbidden
Can't call method "click" on an undefined value at /Users/sprout/.cpan/build/WWW-Mechanize-1.86-1/blib/lib/WWW/Mechanize.pm line 913.
# Looks like your test exited with 255 just after 2.
```

At which point it hangs and I have to kill it.