### PR TITLE
Fix POD and add default test names for button_exists methods

### DIFF
--- a/Mechanize.pm
+++ b/Mechanize.pm
@@ -1774,8 +1774,8 @@ sub lacks_ids_ok {
 
 =head2 $mech->button_exists( $button )
 
-Returns a boolean saying whether the submit C<$button> exists. Does not
-do a test. For that you want C<button_exists_ok> or C<lacks_button_ok>.
+Returns a boolean saying whether a submit button with name C<$button> exists.
+Does not do a test. For that you want C<button_exists_ok> or C<lacks_button_ok>.
 
 =cut
 
@@ -1803,7 +1803,7 @@ sub button_exists_ok {
 
     my $self   = shift;
     my $button = shift;
-    my $msg    = shift;
+    my $msg    = shift || "button with name '$button' exists";
 
     return $TB->ok( $self->button_exists( $button ), $msg );
 }
@@ -1811,7 +1811,7 @@ sub button_exists_ok {
 
 =head2 $mech->lacks_button_ok( $button [, $msg] )
 
-Asserts that the button exists on the page.
+Asserts that no such button exists on the page.
 
 =cut
 
@@ -1820,7 +1820,7 @@ sub lacks_button_ok {
 
     my $self   = shift;
     my $button = shift;
-    my $msg    = shift;
+    my $msg    = shift || "no buttons with name '$button' exist";
 
     return $TB->ok( !$self->button_exists( $button ), $msg );
 }


### PR DESCRIPTION
1. method description for `lacks_button_ok` was **wrong**
1. method description for `button_exists` was quite unspecific
1. default test names were missing