### PR TITLE
Make implicit imports explicit

### DIFF
--- a/Mechanize.pm
+++ b/Mechanize.pm
@@ -66,10 +66,22 @@ results in
 
 use HTML::TokeParser ();
 use WWW::Mechanize ();
-use Test::LongString;
+use Test::LongString qw(
+    contains_string
+    is_string
+    lacks_string
+    like_string
+    unlike_string
+);
 use Test::Builder ();
 use Carp ();
-use Carp::Assert::More;
+use Carp::Assert::More qw(
+    assert_arrayref
+    assert_in
+    assert_is
+    assert_isa
+    assert_nonblank
+);
 
 use parent 'WWW::Mechanize';
 


### PR DESCRIPTION
I was trying to find out where contains_string() was coming from today as I was looking at the source code. I ran perlimports to do the work for me and I figured I'd submit it as a PR. I'm happy for you to close if you don't like it. :)
