### PR TITLE
Fix "Odd number of elements in hash assignment" warning

### DIFF
--- a/Mechanize.pm
+++ b/Mechanize.pm
@@ -67,13 +67,7 @@ results in
 
 use HTML::TokeParser ();
 use WWW::Mechanize ();
-use Test::LongString qw(
-    contains_string
-    is_string
-    lacks_string
-    like_string
-    unlike_string
-);
+use Test::LongString;
 use Test::Builder ();
 use Carp ();
 use Carp::Assert::More qw(


### PR DESCRIPTION
Test::LongString doesn't actually support to selectively export methods,
the expected args is not a list of method names, but a hash to customize
max, lcss and eol, etc.