### PR TITLE
Fix repository metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -39,7 +39,7 @@ if ( $ExtUtils::MakeMaker::VERSION ge '6.46' ) {
             license     => 'https://opensource.org/licenses/artistic-license-2.0',
             homepage    => 'https://github.com/petdance/test-www-mechanize',
             bugtracker  => 'https://github.com/petdance/test-www-mechanize/issues',
-            repository  => 'git@github.com:petdance/test-www-mechanize.git',
+            repository  => 'https://github.com/petdance/test-www-mechanize',
         }
     };
 }


### PR DESCRIPTION
This reverts commit eef8a45359b924258f10eace7d473c9d76421077.

The repository in resources needs to be an actual URL, not a git clone
address. Revert to the https address.