### PR TITLE
Fix failing Test::Pod test

### DIFF
--- a/.github/workflows/testsuite.yml
+++ b/.github/workflows/testsuite.yml
@@ -62,7 +62,7 @@ jobs:
           - "5.10"
 
     container:
-      image: perl:${{ matrix.perl-version }}
+      image: perldocker/perl-tester:${{ matrix.perl-version }}
 
     steps:
       - uses: actions/checkout@v2

--- a/t/pod.t
+++ b/t/pod.t
@@ -7,4 +7,4 @@ use Test::More;
 if ( not eval 'use Test::Pod 1.00;' ) {
     plan skip_all => 'Test::Pod 1.00 required for testing POD' if $@;
 }
-all_pod_files_ok();
+all_pod_files_ok('Mechanize.pm');


### PR DESCRIPTION
When Test::Pod::all_pod_files_ok() does not receive any arguments it tries to find all Perl modules in directories blib or lib. Because the directory lib does not exist, it fails. If fails before it even can find Mechanize.pm